### PR TITLE
docs: add Claude-User and Claude-SearchBot to CDN setup guides (LLMO-5029)

### DIFF
--- a/help/dashboards/optimize-at-edge/akamai-byocdn.md
+++ b/help/dashboards/optimize-at-edge/akamai-byocdn.md
@@ -33,6 +33,8 @@ Set routing for the following user agents:
 ```
  *AdobeEdgeOptimize-AI*
  *ChatGPT-User*
+ *Claude-SearchBot*
+ *Claude-User*
  *GPTBot*
  *OAI-SearchBot*
  *PerplexityBot*

--- a/help/dashboards/optimize-at-edge/cloudflare-byocdn.md
+++ b/help/dashboards/optimize-at-edge/cloudflare-byocdn.md
@@ -129,6 +129,8 @@ After creating the worker, click **Edit code** and replace the default code with
 const AGENTIC_BOTS = [
   'AdobeEdgeOptimize-AI',
   'ChatGPT-User',
+  'Claude-SearchBot',
+  'Claude-User',
   'GPTBot',
   'OAI-SearchBot',
   'PerplexityBot',

--- a/help/dashboards/optimize-at-edge/fastly-byocdn.md
+++ b/help/dashboards/optimize-at-edge/fastly-byocdn.md
@@ -38,7 +38,7 @@ unset req.http.x-edgeoptimize-config;
 unset req.http.x-edgeoptimize-api-key;
 
 if (!req.http.x-edgeoptimize-request
-    && req.http.user-agent ~ "(?i)(AdobeEdgeOptimize-AI|ChatGPT-User|GPTBot|OAI-SearchBot|PerplexityBot|Perplexity-User)") {
+    && req.http.user-agent ~ "(?i)(AdobeEdgeOptimize-AI|ChatGPT-User|Claude-SearchBot|Claude-User|GPTBot|OAI-SearchBot|PerplexityBot|Perplexity-User)") {
   set req.http.x-forwarded-host = req.http.host; # required for identifying the original host
   set req.http.x-edgeoptimize-url = req.url; # required for identifying the original url
   set req.http.x-edgeoptimize-config = "LLMCLIENT=TRUE;"; # required for cache key


### PR DESCRIPTION
## Summary

- Adds `Claude-User` and `Claude-SearchBot` to the agentic bot user-agent lists in three CDN setup guides: Cloudflare Worker, Akamai Property Manager, and Fastly VCL.
- Bots are inserted alphabetically after `ChatGPT-User` in all three files.
- `ClaudeBot` is intentionally excluded — it executes JavaScript and requires separate validation that our pre-rendering layer adds value over its native JS execution (tracked in LLMO-5028).

**Files changed:**
- `help/dashboards/optimize-at-edge/cloudflare-byocdn.md` — `AGENTIC_BOTS` array
- `help/dashboards/optimize-at-edge/fastly-byocdn.md` — VCL `vcl_recv` regex
- `help/dashboards/optimize-at-edge/akamai-byocdn.md` — User-Agent routing criteria list

**Note:** The CloudFront guide references an external code sample (`adobe-rnd/llmo-edge-optimize-samples/cloudfront/cloudfront-function/viewer-request.js`) which also contains an `AGENTIC_BOTS` array. That file will need a separate update.

## Test plan

- [ ] Verify `Claude-SearchBot` and `Claude-User` appear in alphabetical order in all three files.
- [ ] Verify no other content was changed (failover logic, headers, prerequisites).
- [ ] Review CloudFront note and confirm separate ticket or PR covers that code sample.

Jira: https://jira.corp.adobe.com/browse/LLMO-5029

🤖 Generated with [Claude Code](https://claude.com/claude-code)